### PR TITLE
改用 "if ! defined" 解決重複 resource 問題

### DIFF
--- a/manifests/openjdk_java.pp
+++ b/manifests/openjdk_java.pp
@@ -3,30 +3,36 @@ class corp104_karaf::openjdk_java inherits corp104_karaf {
   $package_jdk = 'openjdk-8-jdk'
   $java_home    = '/usr/lib/jvm/java-8-openjdk-amd64'
 
-  $add_apt_package = [ 'python-software-properties', 'software-properties-common' ]
-  Package <| title == $add_apt_package |> {
-    ensure => present,
-    notify => Exec['install-ppa'],
+  $add_apt_packages = [ 'python-software-properties', 'software-properties-common' ]
+  $add_apt_packages.each | String $add_apt_package| {
+    if ! defined(Package[$add_apt_package]){
+      package { $add_apt_package:
+        ensure => present,
+        notify => Exec['install-ppa'],
+      }
+    }
   }
 
-  if $corp104_karaf::http_proxy {
-    Exec <| title == 'install-ppa' |> {
-      path        => '/bin:/usr/sbin:/usr/bin:/sbin',
-      environment => [
-        "http_proxy=${corp104_karaf::http_proxy}",
-      ],
-      command     => "add-apt-repository -y ${corp104_karaf::ppa_openjdk} && apt-get update",
-      user        => 'root',
-      unless      => "/usr/bin/dpkg -l | grep ${package_jre}",
-      before      => Package[$package_jre],
-    }
-  } else {
-    Exec <| title == 'install-ppa' |> {
-      path    => '/bin:/usr/sbin:/usr/bin:/sbin',
-      command => "add-apt-repository -y ${corp104_karaf::ppa_openjdk} && apt-get update",
-      user    => 'root',
-      unless  => "/usr/bin/dpkg -l | grep ${package_jre}",
-      before  => Package[$package_jre],
+  if ! defined(Exec['install-ppa']) {
+    if $corp104_karaf::http_proxy {
+      exec { 'install-ppa':
+        path        => '/bin:/usr/sbin:/usr/bin:/sbin',
+        environment => [
+          "http_proxy=${corp104_karaf::http_proxy}",
+        ],
+        command     => "add-apt-repository -y ${corp104_karaf::ppa_openjdk} && apt-get update",
+        user        => 'root',
+        unless      => "/usr/bin/dpkg -l | grep ${package_jre}",
+        before      => Package[$package_jre],
+      }
+    } else {
+      exec { 'install-ppa':
+        path    => '/bin:/usr/sbin:/usr/bin:/sbin',
+        command => "add-apt-repository -y ${corp104_karaf::ppa_openjdk} && apt-get update",
+        user    => 'root',
+        unless  => "/usr/bin/dpkg -l | grep ${package_jre}",
+        before  => Package[$package_jre],
+      }
     }
   }
 


### PR DESCRIPTION
當兩個有重複 resource 的 module 都用 collector 時，會不執行該 resource
(catalog 中必須要有個地方明確 declare 該 resource)

這問題發生在 ac-api 的 profile 在 include wso2as 和 karaf 模組時，都需要下列資源
* package ['python-software-properties', 'software-properties-common']
* exec ['install-ppa']

原因為 wso2as 需要跑在 java7 上，karaf 需要跑在 java8 上